### PR TITLE
fuss with the build (cstruct 3 compat & link improvements)

### DIFF
--- a/_tags
+++ b/_tags
@@ -1,5 +1,5 @@
 true: color(auto), debug, bin_annot, strict_sequence
-true: package(cstruct cstruct.ppx lwt.unix lwt.ppx)
+true: package(cstruct ppx_cstruct lwt.unix lwt.ppx)
 true: use_rawlink_stubs
 "lib": include
 <*.byte>: linkdep(rawlink_stubs.o), custom

--- a/opam
+++ b/opam
@@ -12,7 +12,8 @@ depends: [
   "ocamlfind" {build}
   "topkg" {build}
   "lwt" {>= "2.4.7"}
-  "cstruct" {>= "1.9"}
+  "cstruct" {>= "3.0.0"}
+  "ppx_cstruct" {build}
   "ocamlbuild" {build}
 ]
 depexts: [[ ["alpine"] ["linux-headers"] ]]

--- a/pkg/META
+++ b/pkg/META
@@ -1,6 +1,6 @@
 version = "%%VERSION_NUM%%"
 description = "Rawlink is a portable interface to BPF/AF_SOCKET"
-requires = "unix lwt.unix lwt cstruct cstruct.ppx"
+requires = "unix lwt.unix lwt cstruct"
 archive(byte) = "rawlink.cma"
 plugin(byte) = "rawlink.cma"
 archive(byte, plugin) = "rawlink.cma"


### PR DESCRIPTION
use the new ppx_cstruct rather than the optional subpackage
cstruct.ppx.  Also, use ppx_cstruct only when building, and don't link
the final product with it.