### PR TITLE
fix compilation on POSIX-like systems by include <netinet/in.h> (where IPPROTO_UDP is defined)

### DIFF
--- a/lib/rawlink_stubs.c
+++ b/lib/rawlink_stubs.c
@@ -35,6 +35,8 @@
 #include <net/bpf.h>
 #endif	/* USE_BPF */
 
+#include <netinet/in.h>
+
 #include <net/if.h>
 
 #include <arpa/inet.h>


### PR DESCRIPTION
some UNIX(-like, see below) variants seem to `#include <netinet/in.h>` from `<arpa/inet.h>`..
source http://pubs.opengroup.org/onlinepubs/7908799/xns/netinetin.h.html

![](http://kinderunix.de/kinderunix.jpg)