### PR TITLE
Add package for cli programs.

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -1,19 +1,27 @@
 (executable
  (name rawcap)
  (modules rawcap)
+ (package rawlink-bin)
+ (public_name rawcap)
  (libraries rawlink))
 
 (executable
  (name rawcap_lwt)
  (modules rawcap_lwt)
+ (package rawlink-bin)
+ (public_name rawcap-lwt)
  (libraries lwt_rawlink))
 
 (executable
  (name rawcap_eio)
  (modules rawcap_eio)
+ (package rawlink-bin)
+ (public_name rawcap-eio)
  (libraries eio_rawlink eio_main))
 
 (executable
  (name test_arp)
  (modules test_arp)
+ (package rawlink-bin)
+ (public_name test-arp)
  (libraries eio_rawlink eio_main arp ethernet))

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,4 @@
 (lang dune 3.2)
 (name rawlink)
+
+(formatting disabled)

--- a/rawlink-bin.opam
+++ b/rawlink-bin.opam
@@ -1,0 +1,39 @@
+opam-version: "2.0"
+maintainer: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+authors: "Christiano F. Haesbaert <haesbaert@haesbaert.org>"
+license: "ISC"
+homepage: "https://github.com/haesbaert/rawlink"
+bug-reports: "https://github.com/haesbaert/rawlink/issues"
+dev-repo: "git+https://github.com/haesbaert/rawlink.git"
+doc: "https://haesbaert.github.io/rawlink/"
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ] ]
+depends: [
+  "ocaml" {>= "4.09.0"}
+  "dune" {>= "3.2"}
+  "rawlink"
+  "rawlink-eio"
+  "rawlink-lwt"
+  "ethernet"
+  "arp"
+  "eio_main"
+]
+depexts: [
+  ["linux-headers"] {os-distribution = "alpine"}
+]
+synopsis: "Portable library to read and write raw packets"
+description: """
+Rawlink is an ocaml library for sending and receiving raw packets at the link
+layer level. Sometimes you need to have full control of the packet, including
+building the full ethernet frame.
+
+The API is platform independent, it uses BPF on real UNIXes and AF_SOCKET on
+linux. Some functionality is sacrificed so that the API is portable enough.
+
+Currently BPF and AF_PACKET are implemented, including filtering capabilities.
+Writing a BPF program is a pain in the ass, so no facilities are provided for
+it. If you need a BPF filter, I suggest you write a small .c file with a
+function that returns the BPF program as a string, check `rawlink_stubs.c` for
+an example.
+"""


### PR DESCRIPTION
This project is failing to build in [ocaml-ci](https://ci.ocamllabs.io/github/haesbaert/rawlink/commit/520207190814ebfc0db9fd4f6d9c6e0f1297732d).

It is caused by the `bin/*` programs requiring extra dependencies that are not present in any opam files. I've created a `raw link-bin.opam` package to cover these programs and pull  in the required opam packages. The wording in the package is copied straight from `rawlink.opam` and possibly needs to be changed.