### PR TITLE
Don't depend on ppx_cstruct, add mli file

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -11,7 +11,6 @@
  (public_name rawlink.lowlevel)
  (modules rawlink_lowlevel)
  (libraries cstruct unix)
- (preprocess (pps ppx_cstruct))
  (foreign_stubs (language c) (names rawlink_stubs)))
 
 (library

--- a/lib/rawlink_lowlevel.ml
+++ b/lib/rawlink_lowlevel.ml
@@ -16,14 +16,28 @@
 
 (* This module is supposed to be used internally only *)
 
-[%%cstruct
-type bpf_hdr = {
-    bh_sec: uint32_t;
-    bh_usec: uint32_t;
-    bh_caplen: uint32_t;
-    bh_datalen: uint32_t;
-    bh_hdrlen: uint16_t;
-} [@@host_endian]]
+(* Hand picked from:
+       [%%cstruct
+       type bpf_hdr = {
+           bh_sec: uint32_t;
+           bh_usec: uint32_t;
+           bh_caplen: uint32_t;
+           bh_datalen: uint32_t;
+           bh_hdrlen: uint16_t;
+       } [@@host_endian]]
+   *)
+let sizeof_bpf_hdr = 18
+let get_bpf_hdr_bh_sec v = Cstruct.HE.get_uint32 v 0
+let get_bpf_hdr_bh_usec v = Cstruct.HE.get_uint32 v 4
+let get_bpf_hdr_bh_caplen v = Cstruct.HE.get_uint32 v 8
+let get_bpf_hdr_bh_datalen v = Cstruct.HE.get_uint32 v 12
+let get_bpf_hdr_bh_hdrlen v = Cstruct.HE.get_uint16 v 16
+let set_bpf_hdr_bh_sec v x = Cstruct.HE.set_uint32 v 0 x
+let set_bpf_hdr_bh_usec v x = Cstruct.HE.set_uint32 v 4 x
+let set_bpf_hdr_bh_caplen v x = Cstruct.HE.set_uint32 v 8 x
+let set_bpf_hdr_bh_datalen v x = Cstruct.HE.set_uint32 v 12 x
+let set_bpf_hdr_bh_hdrlen v x = Cstruct.HE.set_uint16 v 16 x
+(* omitted: hexdump_bpf_hdr_to_buffer *)
 
 type driver =
   | AF_PACKET

--- a/lib/rawlink_lowlevel.ml
+++ b/lib/rawlink_lowlevel.ml
@@ -32,12 +32,7 @@ let get_bpf_hdr_bh_usec v = Cstruct.HE.get_uint32 v 4
 let get_bpf_hdr_bh_caplen v = Cstruct.HE.get_uint32 v 8
 let get_bpf_hdr_bh_datalen v = Cstruct.HE.get_uint32 v 12
 let get_bpf_hdr_bh_hdrlen v = Cstruct.HE.get_uint16 v 16
-let set_bpf_hdr_bh_sec v x = Cstruct.HE.set_uint32 v 0 x
-let set_bpf_hdr_bh_usec v x = Cstruct.HE.set_uint32 v 4 x
-let set_bpf_hdr_bh_caplen v x = Cstruct.HE.set_uint32 v 8 x
-let set_bpf_hdr_bh_datalen v x = Cstruct.HE.set_uint32 v 12 x
-let set_bpf_hdr_bh_hdrlen v x = Cstruct.HE.set_uint16 v 16 x
-(* omitted: hexdump_bpf_hdr_to_buffer *)
+(* omitted: all setters, hexdump_bpf_hdr_to_buffer *)
 
 type driver =
   | AF_PACKET

--- a/lib/rawlink_lowlevel.ml
+++ b/lib/rawlink_lowlevel.ml
@@ -26,13 +26,10 @@
            bh_hdrlen: uint16_t;
        } [@@host_endian]]
    *)
-let sizeof_bpf_hdr = 18
-let get_bpf_hdr_bh_sec v = Cstruct.HE.get_uint32 v 0
-let get_bpf_hdr_bh_usec v = Cstruct.HE.get_uint32 v 4
 let get_bpf_hdr_bh_caplen v = Cstruct.HE.get_uint32 v 8
 let get_bpf_hdr_bh_datalen v = Cstruct.HE.get_uint32 v 12
 let get_bpf_hdr_bh_hdrlen v = Cstruct.HE.get_uint16 v 16
-(* omitted: all setters, hexdump_bpf_hdr_to_buffer *)
+(* omitted: all setters, get_bpf_hdr_bh_sec, get_bpf_hdr_bh_usec, hexdump_bpf_hdr_to_buffer *)
 
 type driver =
   | AF_PACKET

--- a/lib/rawlink_lowlevel.mli
+++ b/lib/rawlink_lowlevel.mli
@@ -1,0 +1,24 @@
+val sizeof_bpf_hdr : int
+val get_bpf_hdr_bh_sec : Cstruct.t -> Cstruct.uint32
+val get_bpf_hdr_bh_usec : Cstruct.t -> Cstruct.uint32
+val get_bpf_hdr_bh_caplen : Cstruct.t -> Cstruct.uint32
+val get_bpf_hdr_bh_datalen : Cstruct.t -> Cstruct.uint32
+val get_bpf_hdr_bh_hdrlen : Cstruct.t -> Cstruct.uint16
+val set_bpf_hdr_bh_sec : Cstruct.t -> Cstruct.uint32 -> unit
+val set_bpf_hdr_bh_usec : Cstruct.t -> Cstruct.uint32 -> unit
+val set_bpf_hdr_bh_caplen : Cstruct.t -> Cstruct.uint32 -> unit
+val set_bpf_hdr_bh_datalen : Cstruct.t -> Cstruct.uint32 -> unit
+val set_bpf_hdr_bh_hdrlen : Cstruct.t -> Cstruct.uint16 -> unit
+type driver = AF_PACKET | BPF
+external opensock :
+  ?filter:string -> ?promisc:bool -> string -> Unix.file_descr
+  = "caml_rawlink_open"
+external dhcp_server_filter : unit -> string = "caml_dhcp_server_filter"
+external dhcp_client_filter : unit -> string = "caml_dhcp_client_filter"
+external driver : unit -> driver = "caml_driver"
+external unix_bytes_read :
+  Unix.file_descr -> Cstruct.buffer -> int -> int -> int
+  = "caml_unix_bytes_read"
+external bpf_align : int -> int -> int = "caml_bpf_align"
+val bpf_split_buffer : Cstruct.t -> int -> Cstruct.t list
+val process_input : Cstruct.t -> int -> Cstruct.t list

--- a/lib/rawlink_lowlevel.mli
+++ b/lib/rawlink_lowlevel.mli
@@ -1,9 +1,3 @@
-val sizeof_bpf_hdr : int
-val get_bpf_hdr_bh_sec : Cstruct.t -> Cstruct.uint32
-val get_bpf_hdr_bh_usec : Cstruct.t -> Cstruct.uint32
-val get_bpf_hdr_bh_caplen : Cstruct.t -> Cstruct.uint32
-val get_bpf_hdr_bh_datalen : Cstruct.t -> Cstruct.uint32
-val get_bpf_hdr_bh_hdrlen : Cstruct.t -> Cstruct.uint16
 type driver = AF_PACKET | BPF
 external opensock :
   ?filter:string -> ?promisc:bool -> string -> Unix.file_descr

--- a/lib/rawlink_lowlevel.mli
+++ b/lib/rawlink_lowlevel.mli
@@ -4,11 +4,6 @@ val get_bpf_hdr_bh_usec : Cstruct.t -> Cstruct.uint32
 val get_bpf_hdr_bh_caplen : Cstruct.t -> Cstruct.uint32
 val get_bpf_hdr_bh_datalen : Cstruct.t -> Cstruct.uint32
 val get_bpf_hdr_bh_hdrlen : Cstruct.t -> Cstruct.uint16
-val set_bpf_hdr_bh_sec : Cstruct.t -> Cstruct.uint32 -> unit
-val set_bpf_hdr_bh_usec : Cstruct.t -> Cstruct.uint32 -> unit
-val set_bpf_hdr_bh_caplen : Cstruct.t -> Cstruct.uint32 -> unit
-val set_bpf_hdr_bh_datalen : Cstruct.t -> Cstruct.uint32 -> unit
-val set_bpf_hdr_bh_hdrlen : Cstruct.t -> Cstruct.uint16 -> unit
 type driver = AF_PACKET | BPF
 external opensock :
   ?filter:string -> ?promisc:bool -> string -> Unix.file_descr

--- a/rawlink.opam
+++ b/rawlink.opam
@@ -13,7 +13,6 @@ depends: [
   "ocaml" {>= "4.09.0"}
   "dune" {>= "3.2"}
   "cstruct" {>= "6.1.0"}
-  "ppx_cstruct"
 ]
 depexts: [
   ["linux-headers"] {os-distribution = "alpine"}


### PR DESCRIPTION
The cstruct ppx was expanded and manually added in the source file. It was only used in one place for a relatively small struct. The hexdump function was omitted.

A lib/rawlink_lowlevel.mli file was added with all members exposed. The intent is to eventually unexpose what is not needed.